### PR TITLE
fix: split weekend issues digest into chunks to avoid Telegram message-too-long error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+__pycache__/

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -76,7 +76,7 @@ and 7 more issues
 - project-four
 ```
 
-- **Message length:** The report is generated as a single message. In the rare case it exceeds Telegram's character limit (4096 chars), it may be truncated. No complex message splitting logic will be implemented.
+- **Message length:** When the report exceeds 4000 characters it is split into multiple Telegram messages. Each continuation message repeats the header with a `(cont.)` suffix. Sections (repo blocks, "No issues" block) are never split across messages.
 
 ---
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,10 @@
 # Repo Digest Log
 
+## 01.03.2026
+
+- Split weekend issues digest into multiple Telegram messages when content exceeds the 4000-char limit, using continuation headers to keep context across chunks.
+- Add unit tests for digest chunking, escaping, and title clamping; extend test runner to cover Python tests.
+
 ## 21.02.2026
 
 - Sort grouped release bullets by semantic version in descending order (for tags like `v0.15.10`) so Telegram output stays naturally ordered within each repository section.

--- a/scripts/generate_digest.py
+++ b/scripts/generate_digest.py
@@ -74,10 +74,10 @@ def generate_report_parts():
         raise Exception("repos.txt not found.")
 
     today = datetime.utcnow().strftime("%a, %Y-%m-%d")
-    header = f"*Weekend issues report — {escape_markdown_v2(today)}*"
+    header_text = f"Weekend issues report — {escape_markdown_v2(today)}"
 
     if not repos:
-        return header, ["No repositories configured in repos\\.txt\\."]
+        return header_text, ["No repositories configured in repos\\.txt\\."]
 
     repos_with_issues_parts = []
     repos_without_issues = []
@@ -109,25 +109,24 @@ def generate_report_parts():
 
             repos_with_issues_parts.append(MESSAGE_SEPARATOR.join(single_repo_parts))
 
-    content_sections = list(repos_with_issues_parts)
-
     if repos_without_issues:
         no_issues_lines = ["\n*No issues*"]
         for repo_slug in repos_without_issues:
             repo_name = repo_slug.split('/')[-1]
             escaped_repo_name = escape_markdown_v2(repo_name)
             no_issues_lines.append(f"\\- {escaped_repo_name}")
-        content_sections.append(MESSAGE_SEPARATOR.join(no_issues_lines))
+        repos_with_issues_parts.append(MESSAGE_SEPARATOR.join(no_issues_lines))
 
-    return header, content_sections
+    return header_text, repos_with_issues_parts
 
 
-def chunk_message(header, content_sections, max_length=TELEGRAM_MAX_LENGTH):
+def chunk_message(header_text, content_sections, max_length=TELEGRAM_MAX_LENGTH):
     """Group content sections into messages that fit within Telegram's character limit."""
+    header = f"*{header_text}*"
     if not content_sections:
         return [header]
 
-    cont_header = header[:-1] + " \\(cont\\.\\)*"
+    cont_header = f"*{header_text} \\(cont\\.\\)*"
     chunks = []
     current = header
     has_content = False

--- a/scripts/generate_digest.py
+++ b/scripts/generate_digest.py
@@ -9,6 +9,8 @@ from datetime import datetime
 API_URL = "https://api.github.com"
 ISSUES_PER_REPO_LIMIT = 10
 TITLE_WORD_CLAMP = 18
+TELEGRAM_MAX_LENGTH = 4000
+MESSAGE_SEPARATOR = "  \n"
 
 def escape_markdown_v2(text):
     """Escapes text for Telegram's MarkdownV2 parser."""
@@ -59,9 +61,10 @@ def fetch_repo_data(repo_slug, token):
     except requests.exceptions.RequestException as e:
         raise Exception(f"GitHub API Error for {repo_slug} (issues): {e}")
 
-def generate_report_text():
+def generate_report_parts():
     """
-    Fetches all data and builds the final, formatted report string.
+    Fetches all data and builds the report header and content sections.
+    Returns (header, content_sections) where content_sections is a list of strings.
     """
     gh_token = os.environ.get("GH_PAT")
     try:
@@ -70,12 +73,12 @@ def generate_report_text():
     except FileNotFoundError:
         raise Exception("repos.txt not found.")
 
-    if not repos:
-        return "No repositories configured in repos\\.txt\\."
+    today = datetime.utcnow().strftime("%a, %Y-%m-%d")
+    header = f"*Weekend issues report — {escape_markdown_v2(today)}*"
 
-    # --- START OF SURGICAL CHANGE ---
-    
-    # Stage 1: Sort repositories into two lists
+    if not repos:
+        return header, ["No repositories configured in repos\\.txt\\."]
+
     repos_with_issues_parts = []
     repos_without_issues = []
 
@@ -86,10 +89,9 @@ def generate_report_text():
         if total_open_count == 0 or not actual_issues:
             repos_without_issues.append(repo_slug)
         else:
-            # Build the multi-line string block for this repo
             repo_name = repo_slug.split('/')[-1]
             escaped_repo_name = escape_markdown_v2(repo_name)
-            
+
             single_repo_parts = [f"\n*{escaped_repo_name}*"]
             for i, issue in enumerate(actual_issues):
                 clamped_title = clamp_title(issue['title'])
@@ -104,27 +106,45 @@ def generate_report_text():
             if total_open_count > len(actual_issues):
                 more_count = total_open_count - len(actual_issues)
                 single_repo_parts.append(f"\nand {more_count} more issues")
-            
-            repos_with_issues_parts.append("  \n".join(single_repo_parts))
 
-    # Stage 2: Assemble the final message from the sorted parts
-    today = datetime.utcnow().strftime("%a, %Y-%m-%d")
-    message_parts = [f"*Weekend issues report — {escape_markdown_v2(today)}*"]
-    
-    # Add the sections for repos that have issues
-    message_parts.extend(repos_with_issues_parts)
+            repos_with_issues_parts.append(MESSAGE_SEPARATOR.join(single_repo_parts))
 
-    # Add the "No issues" section if there are any such repos
+    content_sections = list(repos_with_issues_parts)
+
     if repos_without_issues:
-        message_parts.append("\n*No issues*")
+        no_issues_lines = ["\n*No issues*"]
         for repo_slug in repos_without_issues:
             repo_name = repo_slug.split('/')[-1]
             escaped_repo_name = escape_markdown_v2(repo_name)
-            message_parts.append(f"\\- {escaped_repo_name}")
-            
-    # --- END OF SURGICAL CHANGE ---
-            
-    return "  \n".join(message_parts)
+            no_issues_lines.append(f"\\- {escaped_repo_name}")
+        content_sections.append(MESSAGE_SEPARATOR.join(no_issues_lines))
+
+    return header, content_sections
+
+
+def chunk_message(header, content_sections, max_length=TELEGRAM_MAX_LENGTH):
+    """Group content sections into messages that fit within Telegram's character limit."""
+    if not content_sections:
+        return [header]
+
+    cont_header = header[:-1] + " \\(cont\\.\\)*"
+    chunks = []
+    current = header
+    has_content = False
+
+    for section in content_sections:
+        candidate = current + MESSAGE_SEPARATOR + section
+        if len(candidate) > max_length and has_content:
+            chunks.append(current)
+            current = cont_header
+            has_content = False
+            candidate = current + MESSAGE_SEPARATOR + section
+
+        current = candidate
+        has_content = True
+
+    chunks.append(current)
+    return chunks
 
 def main():
     """
@@ -137,9 +157,11 @@ def main():
         sys.exit("Error: One or more required secrets are not set.")
 
     try:
-        final_message = generate_report_text()
-        print("--- Sending final message to Telegram ---")
-        send_telegram_message(telegram_token, telegram_chat_id, final_message)
+        header, content_sections = generate_report_parts()
+        chunks = chunk_message(header, content_sections)
+        print(f"--- Sending {len(chunks)} message(s) to Telegram ---")
+        for chunk in chunks:
+            send_telegram_message(telegram_token, telegram_chat_id, chunk)
 
     except Exception as e:
         print(f"An error occurred: {e}", file=sys.stderr)

--- a/scripts/generate_digest_test.py
+++ b/scripts/generate_digest_test.py
@@ -6,60 +6,59 @@ from generate_digest import chunk_message, escape_markdown_v2, clamp_title, MESS
 class TestChunkMessage(unittest.TestCase):
 
     def test_returns_header_only_when_no_content(self):
-        result = chunk_message("*Header*", [])
+        result = chunk_message("Header", [])
         self.assertEqual(result, ["*Header*"])
 
     def test_single_chunk_when_content_fits(self):
-        header = "*Report*"
         sections = ["Section A", "Section B"]
-        result = chunk_message(header, sections, max_length=4000)
+        result = chunk_message("Report", sections, max_length=4000)
         self.assertEqual(len(result), 1)
         self.assertIn("Section A", result[0])
         self.assertIn("Section B", result[0])
         self.assertTrue(result[0].startswith("*Report*"))
 
     def test_splits_into_multiple_chunks_when_exceeding_limit(self):
-        header = "*H*"
         sections = ["A" * 50, "B" * 50, "C" * 50]
-        result = chunk_message(header, sections, max_length=70)
+        result = chunk_message("H", sections, max_length=70)
         self.assertGreater(len(result), 1)
         self.assertTrue(all(len(chunk) <= 70 for chunk in result))
 
     def test_continuation_header_on_subsequent_chunks(self):
-        header = "*H*"
         sections = ["A" * 50, "B" * 50]
-        result = chunk_message(header, sections, max_length=60)
+        result = chunk_message("H", sections, max_length=60)
         self.assertTrue(result[0].startswith("*H*"))
         self.assertIn("cont", result[1])
 
     def test_all_sections_present_across_chunks(self):
-        header = "*H*"
         sections = ["AAA", "BBB", "CCC"]
-        result = chunk_message(header, sections, max_length=25)
+        result = chunk_message("H", sections, max_length=25)
         combined = MESSAGE_SEPARATOR.join(result)
         for section in sections:
             self.assertIn(section, combined)
 
     def test_single_oversized_section_still_included(self):
-        header = "*H*"
         sections = ["X" * 200]
-        result = chunk_message(header, sections, max_length=100)
+        result = chunk_message("H", sections, max_length=100)
         self.assertEqual(len(result), 1)
         self.assertIn("X" * 200, result[0])
 
     def test_first_chunk_uses_original_header(self):
-        header = "*Weekend issues report — Sun, 2026\\-03\\-01*"
+        header_text = "Weekend issues report — Sun, 2026\\-03\\-01"
         sections = ["sec1"]
-        result = chunk_message(header, sections, max_length=4000)
-        self.assertTrue(result[0].startswith(header))
+        result = chunk_message(header_text, sections, max_length=4000)
+        self.assertTrue(result[0].startswith(f"*{header_text}*"))
 
     def test_continuation_header_format(self):
-        header = "*Weekend issues report — Sun, 2026\\-03\\-01*"
+        header_text = "Weekend issues report — Sun, 2026\\-03\\-01"
         sections = ["A" * 200, "B" * 200]
-        result = chunk_message(header, sections, max_length=260)
+        result = chunk_message(header_text, sections, max_length=270)
         self.assertIn("\\(cont\\.\\)", result[1])
         self.assertTrue(result[1].startswith("*Weekend issues report"))
         self.assertTrue(result[1].split(MESSAGE_SEPARATOR)[0].endswith("*"))
+
+    def test_wraps_header_in_bold(self):
+        result = chunk_message("Report title", ["content"])
+        self.assertTrue(result[0].startswith("*Report title*"))
 
 
 class TestEscapeMarkdownV2(unittest.TestCase):

--- a/scripts/generate_digest_test.py
+++ b/scripts/generate_digest_test.py
@@ -1,0 +1,89 @@
+import unittest
+
+from generate_digest import chunk_message, escape_markdown_v2, clamp_title, MESSAGE_SEPARATOR
+
+
+class TestChunkMessage(unittest.TestCase):
+
+    def test_returns_header_only_when_no_content(self):
+        result = chunk_message("*Header*", [])
+        self.assertEqual(result, ["*Header*"])
+
+    def test_single_chunk_when_content_fits(self):
+        header = "*Report*"
+        sections = ["Section A", "Section B"]
+        result = chunk_message(header, sections, max_length=4000)
+        self.assertEqual(len(result), 1)
+        self.assertIn("Section A", result[0])
+        self.assertIn("Section B", result[0])
+        self.assertTrue(result[0].startswith("*Report*"))
+
+    def test_splits_into_multiple_chunks_when_exceeding_limit(self):
+        header = "*H*"
+        sections = ["A" * 50, "B" * 50, "C" * 50]
+        result = chunk_message(header, sections, max_length=70)
+        self.assertGreater(len(result), 1)
+        self.assertTrue(all(len(chunk) <= 70 for chunk in result))
+
+    def test_continuation_header_on_subsequent_chunks(self):
+        header = "*H*"
+        sections = ["A" * 50, "B" * 50]
+        result = chunk_message(header, sections, max_length=60)
+        self.assertTrue(result[0].startswith("*H*"))
+        self.assertIn("cont", result[1])
+
+    def test_all_sections_present_across_chunks(self):
+        header = "*H*"
+        sections = ["AAA", "BBB", "CCC"]
+        result = chunk_message(header, sections, max_length=25)
+        combined = MESSAGE_SEPARATOR.join(result)
+        for section in sections:
+            self.assertIn(section, combined)
+
+    def test_single_oversized_section_still_included(self):
+        header = "*H*"
+        sections = ["X" * 200]
+        result = chunk_message(header, sections, max_length=100)
+        self.assertEqual(len(result), 1)
+        self.assertIn("X" * 200, result[0])
+
+    def test_first_chunk_uses_original_header(self):
+        header = "*Weekend issues report — Sun, 2026\\-03\\-01*"
+        sections = ["sec1"]
+        result = chunk_message(header, sections, max_length=4000)
+        self.assertTrue(result[0].startswith(header))
+
+    def test_continuation_header_format(self):
+        header = "*Weekend issues report — Sun, 2026\\-03\\-01*"
+        sections = ["A" * 200, "B" * 200]
+        result = chunk_message(header, sections, max_length=260)
+        self.assertIn("\\(cont\\.\\)", result[1])
+        self.assertTrue(result[1].startswith("*Weekend issues report"))
+        self.assertTrue(result[1].split(MESSAGE_SEPARATOR)[0].endswith("*"))
+
+
+class TestEscapeMarkdownV2(unittest.TestCase):
+
+    def test_escapes_special_characters(self):
+        self.assertEqual(escape_markdown_v2("a.b"), "a\\.b")
+        self.assertEqual(escape_markdown_v2("(x)"), "\\(x\\)")
+        self.assertEqual(escape_markdown_v2("#1"), "\\#1")
+
+    def test_plain_text_unchanged(self):
+        self.assertEqual(escape_markdown_v2("hello"), "hello")
+
+
+class TestClampTitle(unittest.TestCase):
+
+    def test_short_title_unchanged(self):
+        self.assertEqual(clamp_title("short title"), "short title")
+
+    def test_long_title_clamped(self):
+        words = " ".join(f"w{i}" for i in range(25))
+        result = clamp_title(words)
+        self.assertTrue(result.endswith("…"))
+        self.assertEqual(len(result.split()), 18)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 node --test scripts/weekly_releases_period.test.mjs scripts/weekly_releases_telegram.test.mjs
-cd scripts && python3 -m unittest generate_digest_test -v && cd ..
+(cd scripts && python3 -m unittest generate_digest_test -v)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,3 +2,4 @@
 set -euo pipefail
 
 node --test scripts/weekly_releases_period.test.mjs scripts/weekly_releases_telegram.test.mjs
+cd scripts && python3 -m unittest generate_digest_test -v && cd ..


### PR DESCRIPTION
The digest was sent as a single message, which exceeded Telegram's 4096-char
limit when many repos had open issues. Refactor generate_report_parts to return
individual sections and add chunk_message to group them into messages under
4000 chars with "(cont.)" continuation headers. Add unit tests for chunking,
escaping, and title clamping; extend test.sh to run Python tests.

https://claude.ai/code/session_01CfvWMGo69hf5k3Zygigjao