### PR TITLE
migrate telegram sends to ci-shared transport

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,9 @@
 # Repo Digest Log
 
+## 01.03.2026
+
+- Migrate all Telegram sends to ci-shared `notify_telegram.sh` transport (3 scripts, 2 languages → 1 bash wrapper). Eliminates duplicated HTTP/retry logic across Node.js, Python, and embedded-Python call sites.
+
 ## 21.02.2026
 
 - Sort grouped release bullets by semantic version in descending order (for tags like `v0.15.10`) so Telegram output stays naturally ordered within each repository section.

--- a/scripts/ci/notify_telegram.sh
+++ b/scripts/ci/notify_telegram.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "$script_dir/../../vendor/ci-shared/scripts/notify_telegram.sh" "$@"

--- a/scripts/generate_digest.py
+++ b/scripts/generate_digest.py
@@ -1,9 +1,12 @@
 # scripts/generate_digest.py
 import os
-import sys
-import requests
 import re
+import subprocess
+import sys
 from datetime import datetime
+from pathlib import Path
+
+import requests
 
 # --- Constants ---
 API_URL = "https://api.github.com"
@@ -21,20 +24,18 @@ def clamp_title(title):
         return " ".join(words[:TITLE_WORD_CLAMP]) + "…"
     return title
 
+NOTIFY_SCRIPT = Path(__file__).resolve().parent / "ci" / "notify_telegram.sh"
+
 def send_telegram_message(token, chat_id, text, parse_mode="MarkdownV2"):
-    """Sends a message to a Telegram chat."""
-    url = f"https://api.telegram.org/bot{token}/sendMessage"
-    payload = { "chat_id": chat_id, "text": text, "parse_mode": parse_mode, "disable_web_page_preview": True }
-    try:
-        response = requests.post(url, json=payload, timeout=15)
-        response.raise_for_status()
-        print("Telegram message sent successfully.")
-    except requests.exceptions.RequestException as e:
-        print(f"Error sending Telegram message: {e}", file=sys.stderr)
-        if e.response is not None:
-            print(f"Telegram API response: {e.response.text}", file=sys.stderr)
-        # We let the main function handle the exit
-        raise
+    """Sends a message to a Telegram chat via ci-shared transport."""
+    env = {**os.environ, "TELEGRAM_DISABLE_PREVIEW": "true"}
+    if parse_mode and parse_mode != "None":
+        env["TELEGRAM_PARSE_MODE"] = parse_mode
+    subprocess.run(
+        [str(NOTIFY_SCRIPT), token, chat_id, text],
+        check=True,
+        env=env,
+    )
 
 def fetch_repo_data(repo_slug, token):
     """Fetches issue data for a single repository."""

--- a/scripts/notify-missing-repos.sh
+++ b/scripts/notify-missing-repos.sh
@@ -22,50 +22,35 @@ if [ -z "$missing_list" ]; then
   exit 0
 fi
 
-DRY_RUN="$dry_run" MISSING_LIST="$missing_list" python - <<'PY'
-import os
-import re
-import requests
-import sys
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
-def escape_markdown_v2(text):
-    escape_chars = r'_*[]()~`>#+-=|{}.!'
-    return re.sub(f'([{re.escape(escape_chars)}])', r'\\\1', str(text))
-
-token = os.environ.get("TELEGRAM_TOKEN")
-chat_id = os.environ.get("TELEGRAM_CHAT_ID")
-dry_run = os.environ.get("DRY_RUN") == "1"
-missing_raw = os.environ.get("MISSING_LIST", "")
-
-missing_items = [line.strip() for line in missing_raw.splitlines() if line.strip()]
-if not missing_items:
-    print("Missing list was empty after parsing. Skipping notification.")
-    sys.exit(0)
-
-header = f"*{escape_markdown_v2('Missing repos in repos.txt')}*"
-lines = [f"\\- {escape_markdown_v2(repo)}" for repo in missing_items]
-message = "\n".join([header, *lines])
-
-if dry_run:
-    print(message)
-    sys.exit(0)
-
-if not token or not chat_id:
-    print("Missing Telegram configuration. Skipping notification.", file=sys.stderr)
-    sys.exit(0)
-
-url = f"https://api.telegram.org/bot{token}/sendMessage"
-payload = {
-    "chat_id": chat_id,
-    "text": message,
-    "parse_mode": "MarkdownV2",
-    "disable_web_page_preview": True,
+# MarkdownV2: escape special characters in dynamic text.
+escape_mdv2() {
+  printf '%s' "$1" | sed 's/[][\\_.*()`~>#+=|{}!-]/\\&/g'
 }
 
-try:
-    response = requests.post(url, json=payload, timeout=15)
-    if response.status_code >= 400:
-        print(f"Telegram API error: {response.status_code} {response.text}", file=sys.stderr)
-except requests.RequestException as exc:
-    print(f"Failed to send Telegram message: {exc}", file=sys.stderr)
-PY
+# Build message
+header="*$(escape_mdv2 'Missing repos in repos.txt')*"
+body=""
+while IFS= read -r repo; do
+  [ -z "$repo" ] && continue
+  body="${body}
+\\- $(escape_mdv2 "$repo")"
+done <<< "$missing_list"
+
+message="${header}${body}"
+
+if [ "$dry_run" = "1" ]; then
+  printf '%s\n' "$message"
+  exit 0
+fi
+
+token="${TELEGRAM_TOKEN:-}"
+chat_id="${TELEGRAM_CHAT_ID:-}"
+if [ -z "$token" ] || [ -z "$chat_id" ]; then
+  echo "Missing Telegram configuration. Skipping notification." >&2
+  exit 0
+fi
+
+TELEGRAM_PARSE_MODE=MarkdownV2 TELEGRAM_DISABLE_PREVIEW=true \
+  "$script_dir/ci/notify_telegram.sh" "$token" "$chat_id" "$message"

--- a/scripts/weekly_releases.mjs
+++ b/scripts/weekly_releases.mjs
@@ -5,6 +5,10 @@
  * filters to last N days, then posts a digest to Telegram.
  */
 
+import { execFileSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { buildHeader } from "./weekly_releases_period.mjs";
 import { buildReleaseLines, buildTelegramMessages } from "./weekly_releases_telegram.mjs";
 
@@ -47,23 +51,14 @@ async function ghGraphQL(query, variables) {
   return json.data;
 }
 
-async function telegramSend(text) {
-  const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      chat_id: TELEGRAM_CHAT_ID,
-      text,
-      parse_mode: "HTML",
-      disable_web_page_preview: true,
-    }),
-  });
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const NOTIFY_SCRIPT = resolve(SCRIPT_DIR, "ci/notify_telegram.sh");
 
-  const json = await res.json();
-  if (!res.ok || json.ok !== true) {
-    throw new Error(`Telegram send failed: ${JSON.stringify(json)}`);
-  }
+function telegramSend(messages) {
+  execFileSync(NOTIFY_SCRIPT, [TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, ...messages], {
+    stdio: "inherit",
+    env: { ...process.env, TELEGRAM_PARSE_MODE: "HTML", TELEGRAM_DISABLE_PREVIEW: "true" },
+  });
 }
 
 const OWNED_REPOSITORIES_QUERY = `
@@ -208,9 +203,7 @@ async function main() {
   const releaseLines = buildReleaseLines(all);
   const messages = buildTelegramMessages(header, releaseLines);
 
-  for (const message of messages) {
-    await telegramSend(message);
-  }
+  telegramSend(messages);
 
   console.log(`Sent ${all.length} release(s) to Telegram in ${messages.length} message(s).`);
 }

--- a/vendor/ci-shared/scripts/notify_telegram.sh
+++ b/vendor/ci-shared/scripts/notify_telegram.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# vendored-from-repo: https://github.com/igor1309/ci-shared
+# vendored-from-path: scripts/notify_telegram.sh
+# vendored-from-commit: 42d4684c0968e7a147b52ac6589271e571da2bed
+# vendored-on: 2026-03-01
+# vendored-note: includes TELEGRAM_PARSE_MODE / TELEGRAM_DISABLE_PREVIEW
+#   support ahead of upstream (ci-shared#4).
+#
+# Telegram transport: send one or more message chunks to a bot/chat.
+# Chunks are delivered sequentially in argument order. Fail-fast on
+# first error; partial delivery is accepted.
+#
+# Usage: notify_telegram.sh <token> <chat_id> <chunk1> [chunk2...]
+#
+# Environment variables (optional):
+#   TELEGRAM_PARSE_MODE      – "HTML", "MarkdownV2", or "Markdown".
+#                               Omit for plain text (Telegram default).
+#   TELEGRAM_DISABLE_PREVIEW – set to "true" to suppress link previews.
+#
+# Caller is responsible for message formatting, splitting, and
+# choosing which bot/chat to use.
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: notify_telegram.sh <token> <chat_id> <chunk1> [chunk2...]" >&2
+  exit 2
+fi
+
+token="$1"
+chat_id="$2"
+shift 2
+
+extra_args=()
+if [ -n "${TELEGRAM_PARSE_MODE:-}" ]; then
+  extra_args+=(--data-urlencode "parse_mode=${TELEGRAM_PARSE_MODE}")
+fi
+if [ "${TELEGRAM_DISABLE_PREVIEW:-}" = "true" ]; then
+  extra_args+=(--data-urlencode "disable_web_page_preview=true")
+fi
+
+for chunk in "$@"; do
+  curl -fsS --connect-timeout 5 --max-time 20 \
+    --retry 3 --retry-delay 1 --retry-all-errors \
+    -X POST "https://api.telegram.org/bot${token}/sendMessage" \
+    -d "chat_id=${chat_id}" \
+    --data-urlencode "text=${chunk}" \
+    "${extra_args[@]}"
+done


### PR DESCRIPTION
## Summary

Closes #6.

- Vendor `notify_telegram.sh` from ci-shared with `TELEGRAM_PARSE_MODE` and `TELEGRAM_DISABLE_PREVIEW` env var support (ahead of ci-shared#4)
- Add local wrapper `scripts/ci/notify_telegram.sh` delegating to vendored script
- **weekly_releases.mjs**: replace inline `fetch()` transport with `execFileSync` shell-out to wrapper (HTML parse mode)
- **generate_digest.py**: replace `requests.post` transport with `subprocess.run` shell-out to wrapper (MarkdownV2 / plain)
- **notify-missing-repos.sh**: replace embedded Python HTTP block with pure bash message building + wrapper call, eliminating Python dependency from this script entirely

All three call sites now share a single transport with built-in retry (curl `--retry 3`), consistent timeouts, and chunked delivery.

## Test plan

- [x] Existing Node.js tests pass (`./scripts/run_silent.sh "tests" ./scripts/test.sh`)
- [x] Bash syntax validated for all scripts (`bash -n`)
- [x] Python syntax validated (`ast.parse`)
- [ ] Manual: trigger `digest.yml` workflow dispatch and verify Telegram messages arrive
- [ ] Manual: trigger `weekly-releases-to-telegram.yml` workflow dispatch and verify messages arrive